### PR TITLE
Refactor constants and lint

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -126,7 +126,7 @@ func sendTelegramMessage(hc *retryablehttp.Client, botToken, chatID string, succ
 		return
 	}
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		logger.Printf("telegram failed to send message - code [%d] - msg [%s]", resp.StatusCode, string(buf))
 
 		return

--- a/webhook.go
+++ b/webhook.go
@@ -44,9 +44,9 @@ func sendWebhook(c *retryablehttp.Client, sendTime sobaTime, results BackupResul
 	}
 
 	// send to webhook
-	c.RetryMax = 3
-	c.RetryWaitMin = 1 * time.Second
-	c.RetryWaitMax = 3 * time.Second
+	c.RetryMax = webhookRetryMax
+	c.RetryWaitMin = webhookRetryWaitMin
+	c.RetryWaitMax = webhookRetryWaitMax
 
 	var req *retryablehttp.Request
 

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"net/url"
 	"testing"
 	"time"
@@ -61,7 +62,7 @@ func TestWebhookLongFormat(t *testing.T) {
 		MatchHeader("Content-Type", "application/json").
 		MatchType("json").
 		JSON(json).
-		Reply(200)
+		Reply(http.StatusOK)
 
 	gock.Observe(gock.DumpRequest)
 
@@ -101,7 +102,7 @@ func TestWebhookShortFormat(t *testing.T) {
 		MatchHeader("Content-Type", "application/json").
 		MatchType("json").
 		JSON(json).
-		Reply(200)
+		Reply(http.StatusOK)
 
 	gock.Observe(gock.DumpRequest)
 


### PR DESCRIPTION
## Summary
- replace webhook and HTTP retry numbers with named constants
- handle minutes per hour via constant
- use http.StatusOK rather than hard-coded 200
- update tests accordingly

## Testing
- `go vet ./...`
- `go test ./...` *(fails: context deadline exceeded due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683c934416e483208ccb3b15952cec2b