### PR TITLE
deps: bump githosts-utils to latest master (#21)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.25.1
 require (
 	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/jonhadfield/githosts-utils v0.0.0-20260624115506-7000e16a8b90
+	github.com/jonhadfield/githosts-utils v0.0.0-20260624174201-cd080f9bcb4d
 	github.com/slack-go/slack v0.24.0
 	github.com/stretchr/testify v1.11.1
 	gitlab.com/tozd/go/errors v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
-github.com/jonhadfield/githosts-utils v0.0.0-20260624115506-7000e16a8b90 h1:gosJ9XkGjiNLZxN1jqOYC5UeDaeMijw5sPIYCNqhAtM=
-github.com/jonhadfield/githosts-utils v0.0.0-20260624115506-7000e16a8b90/go.mod h1:NMslg2uIdj7qYmXhRUwdtF6C5rm3mD3+3AIbkkOdWDU=
+github.com/jonhadfield/githosts-utils v0.0.0-20260624174201-cd080f9bcb4d h1:oKPJg0/ycqGJ6xEdzfym7Q3CTpEwMG3JL5xQddGFsQk=
+github.com/jonhadfield/githosts-utils v0.0.0-20260624174201-cd080f9bcb4d/go.mod h1:NMslg2uIdj7qYmXhRUwdtF6C5rm3mD3+3AIbkkOdWDU=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
## Summary

Bumps `github.com/jonhadfield/githosts-utils` to the latest master (`cd080f9`, jonhadfield/githosts-utils#21):

- **Retry-aware GitHub request timeout** — `defaultGitHubRequestTimeout` is now derived as one full-length HTTP attempt plus the retry backoff budget, so a throttled enumeration call can complete via `retryablehttp`'s `Retry-After` backoff instead of being cut short by the operation context.
- describeRepos API-mock unit tests for all providers (test-only).

## Test plan

- `go build ./...`, `go mod tidy` — clean
- `go test ./internal/ -run TestGithubRepositoryBackupWithMockAPI` — passes against the new dependency