### PR TITLE
test: fix infinite recursion in skipUnlessLiveGitHub

### DIFF
--- a/internal/backup_test.go
+++ b/internal/backup_test.go
@@ -52,7 +52,9 @@ func skipUnlessLiveGitHub(t *testing.T) {
 		t.Skipf("skipping live GitHub test; set %s=true to run (see #176)", envSobaLiveGitHubTests)
 	}
 
-	skipUnlessLiveGitHub(t)
+	if os.Getenv(envGitHubToken) == "" {
+		t.Skipf(skipGitHubTestMissingToken, envGitHubToken)
+	}
 }
 
 func TestGetBackupInterval(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes an infinite recursion in the `skipUnlessLiveGitHub` test helper introduced in #177. A `replace-all` (converting the per-test token guard into a helper call) also rewrote the helper's *own* token-presence check into a recursive `skipUnlessLiveGitHub(t)` call, so any live GitHub test stack-overflows once `SOBA_LIVE_GITHUB_TESTS` is set.

CI never sets the opt-in, so the default/CI path was unaffected and the bug went unnoticed — it only surfaced when running the live suite to verify the githosts-utils retry fix.

## Fix

Restore the helper's second check to the GitHub-token presence guard.

## Test plan

- `go vet ./internal/` — clean
- Deterministic path (opt-in off): `go test ./internal/ -run GitHub` — passes, live tests skip, mock test runs (~7s)
- Live path (`SOBA_LIVE_GITHUB_TESTS=true`): tests now execute instead of stack-overflowing; the githosts-utils retry-aware timeout was confirmed working (throttled enumeration calls completed at 250–385s). Remaining live failures are pre-existing account-state-dependent assertions and overall throttling, unrelated to this fix.