### PR TITLE
deps: bump githosts-utils to master (GitHub GraphQL body fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.25.1
 require (
 	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/jonhadfield/githosts-utils v0.0.0-20260624174201-cd080f9bcb4d
+	github.com/jonhadfield/githosts-utils v0.0.0-20260625193336-754b7dc17f1f
 	github.com/slack-go/slack v0.24.0
 	github.com/stretchr/testify v1.11.1
 	gitlab.com/tozd/go/errors v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
-github.com/jonhadfield/githosts-utils v0.0.0-20260624174201-cd080f9bcb4d h1:oKPJg0/ycqGJ6xEdzfym7Q3CTpEwMG3JL5xQddGFsQk=
-github.com/jonhadfield/githosts-utils v0.0.0-20260624174201-cd080f9bcb4d/go.mod h1:NMslg2uIdj7qYmXhRUwdtF6C5rm3mD3+3AIbkkOdWDU=
+github.com/jonhadfield/githosts-utils v0.0.0-20260625193336-754b7dc17f1f h1:JPuEWaLUn+PzmcWe/Y9kPABLkFMBoUvpPMKTcOO4UkU=
+github.com/jonhadfield/githosts-utils v0.0.0-20260625193336-754b7dc17f1f/go.mod h1:NMslg2uIdj7qYmXhRUwdtF6C5rm3mD3+3AIbkkOdWDU=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
## What

Bumps `githosts-utils` to the master commit that fixes malformed GitHub GraphQL request bodies (jonhadfield/githosts-utils#22).

## Why

The GitHub backup intermittently **hung for 60–240s** at:

```
listing GitHub user's owned repositories
```

githosts-utils built the viewer-repos / viewer-organizations GraphQL bodies by hand-concatenating JSON and omitted the closing `}`. GitHub intermittently returns HTTP 502 on the invalid body; soba's `retryablehttp` client treats 502 as retryable and backs off for `RetryWaitMin` (60s) before retrying — producing the stall. (The underlying defect dates back to githosts-utils' 2018 init; a recent request-timeout change widened the context from 30s to 240s, which turned the fast failure into a visible hang.)

## Verification

End-to-end against a live account with the bumped dependency: the listing phase completes and cloning begins in ~10s with no stall (was reliably hanging before the bump).