### PR TITLE
deps: bump githosts-utils to dd7970d (regression test)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.25.1
 require (
 	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/jonhadfield/githosts-utils v0.0.0-20260625193336-754b7dc17f1f
+	github.com/jonhadfield/githosts-utils v0.0.0-20260628124917-dd7970d2dc27
 	github.com/slack-go/slack v0.24.0
 	github.com/stretchr/testify v1.11.1
 	gitlab.com/tozd/go/errors v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
-github.com/jonhadfield/githosts-utils v0.0.0-20260625193336-754b7dc17f1f h1:JPuEWaLUn+PzmcWe/Y9kPABLkFMBoUvpPMKTcOO4UkU=
-github.com/jonhadfield/githosts-utils v0.0.0-20260625193336-754b7dc17f1f/go.mod h1:NMslg2uIdj7qYmXhRUwdtF6C5rm3mD3+3AIbkkOdWDU=
+github.com/jonhadfield/githosts-utils v0.0.0-20260628124917-dd7970d2dc27 h1:fPA7LF7V41YlSxUnuZqlBEvq5cR+fOj3hZpTUnJzzas=
+github.com/jonhadfield/githosts-utils v0.0.0-20260628124917-dd7970d2dc27/go.mod h1:NMslg2uIdj7qYmXhRUwdtF6C5rm3mD3+3AIbkkOdWDU=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
## What

Moves the `githosts-utils` pin to current master (`dd7970d`), which adds the regression test guarding the GitHub GraphQL request-body fix (jonhadfield/githosts-utils#23).

## Note

No functional change for soba — that commit only adds a `_test.go` file, which Go does not compile into dependents. This bump just keeps the pin current.

Build verified locally.