### PR TITLE
deps: migrate to githosts-utils /v2 module path (v2.1.1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,12 @@ module github.com/jonhadfield/soba
 
 go 1.25.1
 
-//replace github.com/jonhadfield/githosts-utils => ../githosts-utils
+//replace github.com/jonhadfield/githosts-utils/v2 => ../githosts-utils
 
 require (
 	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/jonhadfield/githosts-utils v0.0.0-20260628124917-dd7970d2dc27
+	github.com/jonhadfield/githosts-utils/v2 v2.1.1
 	github.com/slack-go/slack v0.24.0
 	github.com/stretchr/testify v1.11.1
 	gitlab.com/tozd/go/errors v0.11.1
@@ -33,4 +33,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-//replace github.com/jonhadfield/githosts-utils => ../githosts-utils
+//replace github.com/jonhadfield/githosts-utils/v2 => ../githosts-utils

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
-github.com/jonhadfield/githosts-utils v0.0.0-20260628124917-dd7970d2dc27 h1:fPA7LF7V41YlSxUnuZqlBEvq5cR+fOj3hZpTUnJzzas=
-github.com/jonhadfield/githosts-utils v0.0.0-20260628124917-dd7970d2dc27/go.mod h1:NMslg2uIdj7qYmXhRUwdtF6C5rm3mD3+3AIbkkOdWDU=
+github.com/jonhadfield/githosts-utils/v2 v2.1.1 h1:0LMpAogF7pBif5B0NmRMITeUSe0V+Kib/tquS6b5IDs=
+github.com/jonhadfield/githosts-utils/v2 v2.1.1/go.mod h1:7wtBKi38/c2pYJJAGo+dJX8ykryu0vjOrmLs6VDh028=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/internal/azure_devops.go
+++ b/internal/azure_devops.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"os"
 
-	"github.com/jonhadfield/githosts-utils"
+	"github.com/jonhadfield/githosts-utils/v2"
 	"gitlab.com/tozd/go/errors"
 )
 

--- a/internal/backup.go
+++ b/internal/backup.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/go-co-op/gocron/v2"
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/jonhadfield/githosts-utils"
+	"github.com/jonhadfield/githosts-utils/v2"
 	"gitlab.com/tozd/go/errors"
 )
 

--- a/internal/backup_test.go
+++ b/internal/backup_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonhadfield/githosts-utils"
+	"github.com/jonhadfield/githosts-utils/v2"
 
 	"github.com/stretchr/testify/require"
 )

--- a/internal/bitbucket.go
+++ b/internal/bitbucket.go
@@ -5,7 +5,7 @@ import (
 
 	"gitlab.com/tozd/go/errors"
 
-	"github.com/jonhadfield/githosts-utils"
+	"github.com/jonhadfield/githosts-utils/v2"
 )
 
 func Bitbucket(backupDir string) *ProviderBackupResults {

--- a/internal/encryption_test.go
+++ b/internal/encryption_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jonhadfield/githosts-utils"
+	"github.com/jonhadfield/githosts-utils/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/gitea.go
+++ b/internal/gitea.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"os"
 
-	"github.com/jonhadfield/githosts-utils"
+	"github.com/jonhadfield/githosts-utils/v2"
 	"gitlab.com/tozd/go/errors"
 )
 

--- a/internal/github.go
+++ b/internal/github.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"os"
 
-	"github.com/jonhadfield/githosts-utils"
+	"github.com/jonhadfield/githosts-utils/v2"
 
 	"gitlab.com/tozd/go/errors"
 )

--- a/internal/github_mock_test.go
+++ b/internal/github_mock_test.go
@@ -12,7 +12,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/jonhadfield/githosts-utils"
+	"github.com/jonhadfield/githosts-utils/v2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/gitlab.go
+++ b/internal/gitlab.go
@@ -5,7 +5,7 @@ import (
 
 	"gitlab.com/tozd/go/errors"
 
-	"github.com/jonhadfield/githosts-utils"
+	"github.com/jonhadfield/githosts-utils/v2"
 )
 
 func Gitlab(backupDir string) *ProviderBackupResults {

--- a/internal/sourcehut.go
+++ b/internal/sourcehut.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"os"
 
-	"github.com/jonhadfield/githosts-utils"
+	"github.com/jonhadfield/githosts-utils/v2"
 
 	"gitlab.com/tozd/go/errors"
 )

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"testing"
 
-	githosts "github.com/jonhadfield/githosts-utils"
+	githosts "github.com/jonhadfield/githosts-utils/v2"
 	"github.com/stretchr/testify/require"
 	tozdErrors "gitlab.com/tozd/go/errors"
 )

--- a/internal/webhook_test.go
+++ b/internal/webhook_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/jonhadfield/githosts-utils"
+	"github.com/jonhadfield/githosts-utils/v2"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 )


### PR DESCRIPTION
## What

Migrates to the `/v2` module path for `githosts-utils` and pins the `v2.1.1` release.

- Updates all imports to `github.com/jonhadfield/githosts-utils/v2`.
- Replaces the previous pseudo-version pin (`v0.0.0-…`) with the real tag `v2.1.1`.
- Fixes the commented-out local `replace` directives to the `/v2` path.

## Why

`githosts-utils` adopted the `/v2` module path (jonhadfield/githosts-utils#24) so its `v2.x` tags are valid Go module versions. Until now soba could only pin pseudo-versions; it can now track tagged releases.

The package name is unchanged (`githosts`), so only import paths change — no code changes.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./...` all pass against `v2.1.1`.