### PR TITLE
refactor: extract Azure DevOps display label into a constant

### DIFF
--- a/internal/backup.go
+++ b/internal/backup.go
@@ -288,9 +288,9 @@ func displayAzureDevOpsStartupConfig() {
 		return
 	}
 
-	logProviderOrgs("Azure DevOps", envAzureDevOpsOrgs)
-	logProviderCompareMethod("Azure DevOps", envAzureDevOpsCompare)
-	logProviderBackupLFS("Azure DevOps", envAzureDevOpsBackupLFS)
+	logProviderOrgs(providerLabelAzureDevOps, envAzureDevOpsOrgs)
+	logProviderCompareMethod(providerLabelAzureDevOps, envAzureDevOpsCompare)
+	logProviderBackupLFS(providerLabelAzureDevOps, envAzureDevOpsBackupLFS)
 }
 
 func getBackupInterval() int {

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -104,6 +104,9 @@ const (
 	providerNameGitea             = "Gitea"
 	providerNameSourcehut         = "Sourcehut"
 
+	// provider display labels
+	providerLabelAzureDevOps = "Azure DevOps"
+
 	// compare types
 	compareTypeRefs  = "refs"
 	compareTypeClone = "clone"


### PR DESCRIPTION
Resolves the remaining SonarQube go:S1192 finding: the "Azure DevOps" label literal was repeated three times in the startup-config logging introduced by #195.