### PR TITLE
ci: fix sonar test-file exclusion to match subdirectories

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,4 +11,4 @@ sonar.projectName=soba
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 
-sonar.exclusions=*_test.go
+sonar.exclusions=**/*_test.go


### PR DESCRIPTION
The existing `sonar.exclusions=*_test.go` pattern only matches the repository root; the test files all live under `internal/`, so they were analysed despite the exclusion intent — and their duplicated setup boilerplate (7.2% on new code) failed the quality gate. `**/*_test.go` applies the exclusion as intended.