### PR TITLE
ci: keep codeql-action versions in lockstep and stop dependabot review failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # The codeql-action sub-actions (init/autobuild/analyze/upload-sarif) must
+      # always move together: CodeQL aborts if the version that wrote the config
+      # differs from the version that runs the analysis.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,6 +25,14 @@ jobs:
       issues: read
       id-token: write
 
+    env:
+      # Dependabot-triggered runs read the Dependabot secret store rather than
+      # the Actions one, so this is empty unless CLAUDE_CODE_OAUTH_TOKEN has
+      # been added there too. Surfaced as an env var so the step below can skip
+      # instead of failing the check. The secrets context is not available in a
+      # job-level `if`, which is why the guard sits on the step.
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -33,9 +41,10 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        if: env.CLAUDE_CODE_OAUTH_TOKEN != ''
         uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'dependabot[bot],dependabot'
           prompt: |
             Please review this pull request and provide feedback on:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,14 +29,14 @@ jobs:
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+      uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -12,6 +12,10 @@ jobs:
   Trivy-Scan:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      security-events: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -44,6 +48,11 @@ jobs:
           severity: 'CRITICAL'
 
       - name: DEBUG Upload Trivy scan results to GitHub Security tab
+        # Dependabot-triggered runs get a read-only GITHUB_TOKEN no matter what
+        # this block requests, so the upload fails with "Resource not accessible
+        # by integration". The scan itself still runs on those PRs; only the
+        # publish to the Security tab is skipped.
+        if: github.actor != 'dependabot[bot]'
         uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -44,6 +44,6 @@ jobs:
           severity: 'CRITICAL'
 
       - name: DEBUG Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Fixes two CI problems surfaced while reviewing the open Dependabot PRs.

## 1. CodeQL version skew (supersedes #201 and #202)

Dependabot treats `github/codeql-action`'s sub-actions as four independent dependencies, so #201 bumped `analyze` to 4.37.4 while `init` and `autobuild` stayed at 4.37.3. CodeQL refuses to run against a config written by a different version:

```
##[error]Loaded a configuration file for version '4.37.3', but running version '4.37.4'
##[error]analyze post-action step failed
```

That is why `Analyze (go)` fails and `CodeQL` goes neutral on #201 — a real failure, not a flake.

This moves all four refs to 4.37.4 in one commit:

| File | Step |
|---|---|
| `codeql-analysis.yml` | `init`, `autobuild`, `analyze` |
| `trivy.yml` | `upload-sarif` |

Verified `f205ea1c3313d32999d8d6a48b4f6530d4437b38` resolves to tag `v4.37.4` upstream. Version comments now carry the full patch version so skew is visible in review.

A `groups:` block in `dependabot.yml` keeps the four together in future bumps.

**#201 and #202 can be closed once this merges.**

## 2. `claude-review` failing on every Dependabot PR

```
Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
```

Dependabot-triggered runs read the *Dependabot* secret store, not the Actions one. `CLAUDE_CODE_OAUTH_TOKEN` only exists in the latter, so it resolves empty and the action hard-fails before review starts. (`SONAR_TOKEN` is in both stores, which is why Sonar passes on the same PRs.)

The step now skips when the token is absent rather than failing the check. `allowed_bots` is left as-is — the intent to review Dependabot PRs is preserved, and **adding `CLAUDE_CODE_OAUTH_TOKEN` to the Dependabot secret store re-enables reviews with no further workflow change**:

```
gh secret set CLAUDE_CODE_OAUTH_TOKEN --app dependabot
```

The guard sits on the step rather than the job because the `secrets` context is not available in a job-level `if`.

## Verification

- All workflow files and `dependabot.yml` parse as valid YAML
- Every pinned SHA re-verified against its upstream tag
- No behaviour change to the Go build or test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)