### PR TITLE
ci: make the release image scan a real gate and scope workflow tokens

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,6 +10,8 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
   build-and-push-docker-image:
     runs-on: ubuntu-latest
     name: Docker Build, Tag, Push
+    permissions:
+      contents: read
+      packages: write   # push to ghcr.io using github.token
     steps:
     -
       name: Checkout
@@ -45,18 +48,35 @@ jobs:
         file: ./docker/Dockerfile
         build-args: TAG=${{ env.TAG }}
         push: false
+        load: true    # without this the image stays in the buildkit cache and
+                      # the scan below silently falls back to the copy already
+                      # published on Docker Hub, i.e. the previous release
         tags: |
           ${{ github.repository }}:latest
           ${{ github.repository }}:${{ env.TAG }}
           ghcr.io/${{ github.repository }}:latest
           ghcr.io/${{ github.repository }}:${{ env.TAG }}
 
-    - name: trivy image scan
+    # Reported for visibility, does not block. The release binary currently
+    # carries Go stdlib HIGHs that clear only when goreleaser builds against a
+    # newer toolchain.
+    - name: trivy image scan (report HIGH and CRITICAL)
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
-        image-ref: ${{ github.repository }}:latest
+        image-ref: ${{ github.repository }}:${{ env.TAG }}
         exit-code: 0
-        severity: UNKNOWN,LOW,MEDIUM
+        severity: HIGH,CRITICAL
+        ignore-unfixed: true
+
+    # The gate. Scans the image built above, not whatever :latest happens to be
+    # on Docker Hub, and fails the release before the push step runs.
+    - name: trivy image scan (fail on CRITICAL)
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        image-ref: ${{ github.repository }}:${{ env.TAG }}
+        exit-code: 1
+        severity: CRITICAL
+        ignore-unfixed: true
 
     -
       name: push image

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -9,6 +9,9 @@ jobs:
   sonarcloud:
     name: SonarQube
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read   # scanner reads PR metadata via GITHUB_TOKEN
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,13 @@
-FROM alpine:3.22.0
+# Track the 3.22 branch rather than the frozen 3.22.0 point release: a pinned
+# patch tag never receives security updates, which left 19 fixable HIGH/CRITICAL
+# CVEs (openssl, musl, zlib) baked into every published image.
+FROM alpine:3.22
 
 LABEL maintainer="Jon Hadfield jon@lessknown.co.uk"
 
 RUN addgroup -S nonroot \
     && adduser -S nonroot -G nonroot \
+    && apk upgrade --no-cache \
     && apk add --update --no-cache bash ca-certificates curl git git-lfs grep jq \
     && rm -f "/var/cache/apk/*"
 


### PR DESCRIPTION
Follow-up to the CI review. Independent of #205 — no overlapping files.

## The release scan was scanning the previous release

`release.yml` looked like a vulnerability gate before publish. It was decorative, for three independent reasons — all confirmed in the 1.4.8 run ([`30396583662`](https://github.com/jonhadfield/soba/actions/runs/30396583662)):

```
20:39:00   build #1   push: false, no load  -> image never enters the local docker store
20:39:11   Running Trivy with options: trivy image ***/soba:latest   -> resolved from Docker Hub
20:39:14   ***/soba:latest (alpine 3.22.0)  69 vulns
20:39:15   docker buildx build ... --push   -> the new image is published
```

1. **Wrong image.** `push: false` without `load: true` leaves the result in the buildkit cache, so trivy pulled `:latest` from Docker Hub. Note the ordering — the scan finished at `:14`, the image being released was pushed at `:15`.
2. **Wrong severities.** `severity: UNKNOWN,LOW,MEDIUM` filtered out exactly what you would gate on.
3. **Could not fail.** `exit-code: 0`.

### Fix

- `load: true` on the build, so the image exists locally
- scan by version tag, not `:latest`, so it cannot silently resolve to the registry copy again
- split into two steps: HIGH+CRITICAL **reported**, CRITICAL **fails** the job before `push image` runs

## Base image was frozen on a tag that never updates

Turning the gate on surfaced **19 fixable HIGH/CRITICAL** CVEs (openssl, musl, zlib) — all from `alpine:3.22.0`. A pinned point-release tag receives no updates, and `apk add` does not touch already-installed packages, so they were baked into every published image.

Measured with trivy `--severity HIGH,CRITICAL --ignore-unfixed`:

| Base | CRITICAL | HIGH |
|---|---|---|
| `alpine:3.22.0` (before) | 2 | 17 |
| `alpine:3.22` -> 3.22.5 (after) | **0** | **0** |

Tracking the branch plus `apk upgrade --no-cache` clears all 19 and stops the base silently rotting between refreshes.

## Least-privilege tokens

`release.yml`, `golangci-lint.yml` and `sonar.yml` had no `permissions:` block, inheriting the repo default of **write**. Now scoped — `release.yml` keeps `packages: write` for ghcr.

## Effect on the next release

**It ships, with the gate active.** CRITICAL is 0 once the base is fixed. The 10 remaining Go stdlib HIGHs (binary built with Go 1.25.10; fixed in >=1.25.13) are reported but non-blocking — they clear when goreleaser next builds against a newer toolchain.

## Verification

- All workflow YAML parses
- Base-image CVE counts measured directly with trivy 0.74.0, before and after
- **Not verified:** the image build itself — no docker daemon available here. First real exercise is the next tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
