### PR TITLE
ci: run tests in Actions, align Go versions, tighten triggers and pins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,10 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/go:1.24.0
+      # Must track the go directive in go.mod (1.25.1). On an older image Go
+      # silently downloads a matching toolchain on every build, and would fail
+      # outright under GOTOOLCHAIN=local.
+      - image: cimg/go:1.25.1
     steps:
       - checkout
       - run:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,22 +4,26 @@ on:
     tags:
       - '*'
     branches:
-      - '*'
+      - '**'
   pull_request:
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      # Checkout first so setup-go can find go.sum and cache modules, and read
+      # the version from go.mod rather than a literal that drifts from it.
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: '1.25.1'
-          cache: false
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: latest
+          # Pinned deliberately: "latest" lets an upstream release change the
+          # result with no change to this repo. v2.13.0 is the version the
+          # action last resolved to and passed with.
+          version: v2.13.0
           args: --timeout=5m -v --config .golangci.yml
           skip-cache: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      # Checkout first so setup-go can find go.sum and cache modules, and read
+      # the version from go.mod rather than a literal that drifts from it.
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+
+      # Mirrors the CircleCI invocation. The suite needs no credentials: the
+      # live provider tests skip unless their tokens are set, and the backup
+      # directory is created by the test preflight.
+      - name: Run tests
+        run: go test -v -p 1 -parallel 1 -failfast ./...

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -2,11 +2,11 @@ name: "Trivy Code Scan"
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: '0 0 * * 1'
-  watch:
-    types: [started]
 
 jobs:
   Trivy-Scan:


### PR DESCRIPTION
Third and final PR from the CI review. Branched off `main`; overlaps #205 (`trivy.yml`) and #206 (`golangci-lint.yml`) only in distinct hunks, so they auto-merge in any order.

## 1. Tests never ran in GitHub Actions

`go test` appeared in **zero** workflows. The suite ran only in CircleCI, so merge protection rested on one external provider — if it were disconnected or its token lapsed, PRs would go green with nothing having run the tests, and nothing in the Actions UI would show it.

Adds a `Test` job mirroring the CircleCI invocation. It needs no secrets: live provider tests skip unless their tokens are set, and `preflight()` creates its own temp backup directory.

Verified locally in a clean environment:

```
$ env -u GITLAB_TOKEN go test -p 1 -parallel 1 -failfast ./...
?     github.com/jonhadfield/soba          [no test files]
ok    github.com/jonhadfield/soba/internal 6.620s
```

(The token had to be unset because a stale local `GITLAB_TOKEN` activates the live paths and 401s — the same reason the suite appears to fail on a developer machine but passes in CI.)

## 2. CircleCI ran a different Go than the project targets

`cimg/go:1.24.0` against a `go.mod` requiring `1.25.1`. It passed only because `GOTOOLCHAIN=auto` silently downloaded 1.25.1 on every build — a per-build cost, and a hard failure under `GOTOOLCHAIN=local`. Now `cimg/go:1.25.1`.

**Left alone deliberately:** the `version: 2` → `2.1` bump. It is cosmetic here (no orbs or commands), the CircleCI CLI is not available to validate it, and this is currently the only place the tests run. Not worth the risk in the same PR that adds the Actions safety net.

## 3. Trivy scanned on every repository star

`watch: types: [started]` fires when someone stars the repo. Of the last 100 runs:

```
51 push        35 pull_request        8 schedule        6 watch
```

Six full scans from stars, plus the unscoped `push` trigger duplicating every `pull_request` run — the doubled `Trivy-Scan` on each PR. Now `push` is scoped to `main` and the star trigger is gone. PR, main and weekly coverage are unchanged.

## 4. golangci-lint was unpinned

`version: latest` lets an upstream release change your build with no change to this repo — squarely at odds with the SHA-pinning applied to every action. This is not hypothetical: v2.13.1 shipped an hour before this PR was written.

Pinned to **v2.13.0** — the version the action last resolved to and passed with, per the lint run on #205:

```
Installing golangci-lint binary v2.13.0...
golangci-lint has version 2.13.0 built with go1.27.0 ...
```

Dependabot will offer upgrades from here.

## 5. Lint skipped branches with a slash in the name

`branches: ['*']` does not match `/`, so pushes to `dependabot/...` or `fix/...` never triggered lint. Confirmed on `fix/codeql-action-version-skew` — only `pull_request` runs existed, no `push` runs. Now `'**'`.

Also reorders `checkout` before `setup-go` so module caching works (the reason `cache: false` was needed), and reads the Go version from `go.mod` instead of a literal that drifts from it.

## Verification

- All workflow YAML parses
- Test suite confirmed green in a clean environment
- Trigger and lint-version claims measured from actual run history, quoted above
- **Not verified:** the CircleCI image bump, which first runs on merge

## Still open from the review, not addressed here

Deliberately left for later to avoid conflicting with #206, which touches both files: the dead `refs/heads/main` condition in `release.yml`, `git describe --tags` vs `github.ref_name`, the double docker build, `curl -fL` in the Dockerfile, and the amd64-only image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
