### PR TITLE
ci: derive the release tag from github.ref_name and fail the curl loudly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,13 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    # This workflow only triggers on tag pushes, so github.ref_name is the tag
+    # name. It replaces git describe --tags, which depended on the tag object
+    # being present in a fetch-depth 1 checkout and would emit a
+    # <tag>-<n>-g<sha> string if HEAD were ever not exactly on a tag.
     -
-      if: startsWith(github.ref, 'refs/heads/main')
-      run: echo "TAG=latest" >> $GITHUB_ENV
-
-    -
-      if: startsWith(github.ref, 'refs/tags')
-      run: echo "TAG=$(git describe --tags)" >> $GITHUB_ENV
+      name: Set release tag
+      run: echo "TAG=${{ github.ref_name }}" >> $GITHUB_ENV
 
     -
       name: build image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN addgroup -S nonroot \
 ARG TAG
 
 WORKDIR /tmp
-RUN curl -L --proto "=https" --tlsv1.2 -o soba.tar.gz "https://github.com/jonhadfield/soba/releases/download/${TAG}/soba_linux_amd64.tar.gz" \
+RUN curl -fL --proto "=https" --tlsv1.2 -o soba.tar.gz "https://github.com/jonhadfield/soba/releases/download/${TAG}/soba_linux_amd64.tar.gz" \
     && tar -xvzf soba.tar.gz \
     && rm ./*.gz \
     && mv ./soba /soba \


### PR DESCRIPTION
Final cleanup from the CI review. Smaller than advertised — while preparing it I re-checked two of my own review findings against the 1.4.8 build log and both were overstated. Details below.

## Changes

**Dead code in `release.yml`.** The workflow triggers only on `push: tags`, so `github.ref` is always `refs/tags/*` and this could never run:

```yaml
- if: startsWith(github.ref, 'refs/heads/main')
  run: echo "TAG=latest" >> $GITHUB_ENV
```

**`git describe --tags` → `github.ref_name`.** The old command depends on the tag object being present in a `fetch-depth: 1` checkout, and emits `<tag>-<n>-g<sha>` if HEAD is ever not exactly on a tag — which would build a release-asset URL that doesn't exist. `github.ref_name` is the tag name directly. Verified it matches: the 1.4.8 run used `--build-arg TAG=1.4.8`, and `github.ref_name` for `refs/tags/1.4.8` is `1.4.8`.

**`curl -L` → `curl -fL` in the Dockerfile.** Without `-f`, a 404 on the release asset is written to `soba.tar.gz` and the build fails later inside `tar` with a message that points nowhere near the real cause. With it, the download fails immediately with the HTTP status.

## Dropped from the plan, with evidence

**The "double build" is not wasted work.** I flagged the two `build-push-action` steps as a full rebuild. The log shows the second build is entirely cache-hits, finishing in about 0.2s:

```
#5 CACHED   #6 CACHED   #7 CACHED   #8 CACHED
#9 exporting to image
#9 writing image sha256:8d310b8e... done
#9 naming to docker.io/***/soba:latest done
```

Restructuring the publish path to save 0.2s would add risk for no gain.

**CircleCI `version: 2` → `2.1` still left alone.** Purely cosmetic here — no orbs or commands — and the CircleCI CLI is not available to validate that the implicit `build` job still resolves. Now that #207 runs the tests in Actions the blast radius is smaller, but the change still buys nothing.

**Multi-arch image not attempted.** The Dockerfile hardcodes `soba_linux_amd64.tar.gz`, so arm64 support means `setup-qemu-action` + `setup-buildx-action` + `platforms:` + arch selection in the Dockerfile. That is a feature with a real testing burden, not cleanup — worth its own PR and an explicit decision, given goreleaser already produces arm64 binaries.

## Correction to #206

Also posted [as a comment there](https://github.com/jonhadfield/soba/pull/206#issuecomment-5358670851). That PR's description claimed the old trivy step scanned the previously published image. It did not. The build runs on the `docker` driver, which exports to the local image store:

```
#0 building with "default" instance using docker driver
#10 writing image sha256:8d310b8e... done
```

So the image was present locally and trivy scanned the correct, newly built one. `load: true` fixed nothing that was broken — it stays as an explicit statement of intent, and becomes load-bearing if a container driver is ever introduced.

What #206 genuinely fixed is unchanged: the severity filter excluded HIGH and CRITICAL, `exit-code: 0` meant the step could never fail, and the frozen `alpine:3.22.0` base carried 19 fixable HIGH/CRITICAL CVEs into every published image.

## Verification

- `release.yml` parses; `github.ref_name` cross-checked against the tag the last release actually built with
- **Not verified:** neither change executes until the next tag push. Both are on the release path, which cannot be exercised without cutting a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
