### PR TITLE
feat: publish the docker image for arm64 as well as amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,19 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    # arm64 layers are built under emulation on the amd64 runner.
+    -
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+    # Multi-platform builds require the docker-container driver; the default
+    # docker driver cannot produce a manifest list. Note this also makes the
+    # load: true below load-bearing rather than incidental: with the container
+    # driver the build result does NOT reach the local image store on its own.
+    -
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
     # This workflow only triggers on tag pushes, so github.ref_name is the tag
     # name. It replaces git describe --tags, which depended on the tag object
     # being present in a fetch-depth 1 checkout and would emit a
@@ -40,22 +53,21 @@ jobs:
       name: Set release tag
       run: echo "TAG=${{ github.ref_name }}" >> $GITHUB_ENV
 
+    # Built for a single platform and loaded locally so the scan below has a
+    # real image to inspect: a multi-platform result cannot be loaded into the
+    # docker image store. The layers are reused by the push build, which is a
+    # cache hit for amd64.
     -
-      name: build image
+      name: build image for scanning
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
         context: ./docker
         file: ./docker/Dockerfile
         build-args: TAG=${{ env.TAG }}
+        platforms: linux/amd64
         push: false
-        load: true    # without this the image stays in the buildkit cache and
-                      # the scan below silently falls back to the copy already
-                      # published on Docker Hub, i.e. the previous release
-        tags: |
-          ${{ github.repository }}:latest
-          ${{ github.repository }}:${{ env.TAG }}
-          ghcr.io/${{ github.repository }}:latest
-          ghcr.io/${{ github.repository }}:${{ env.TAG }}
+        load: true
+        tags: ${{ github.repository }}:${{ env.TAG }}
 
     # Reported for visibility, does not block. The release binary currently
     # carries Go stdlib HIGHs that clear only when goreleaser builds against a
@@ -68,8 +80,8 @@ jobs:
         severity: HIGH,CRITICAL
         ignore-unfixed: true
 
-    # The gate. Scans the image built above, not whatever :latest happens to be
-    # on Docker Hub, and fails the release before the push step runs.
+    # The gate: fails the job before the push step, so a CRITICAL finding stops
+    # the release rather than being published and reported afterwards.
     - name: trivy image scan (fail on CRITICAL)
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
@@ -78,6 +90,7 @@ jobs:
         severity: CRITICAL
         ignore-unfixed: true
 
+    # Publishes a manifest list so a single tag serves both architectures.
     -
       name: push image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -85,6 +98,7 @@ jobs:
         context: ./docker
         file: ./docker/Dockerfile
         build-args: TAG=${{ env.TAG }}
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: |
           ${{ github.repository }}:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,13 @@ RUN addgroup -S nonroot \
 
 ARG TAG
 
+# Supplied automatically by buildx, one value per platform being built
+# (amd64, arm64). Matches Go's naming, and therefore the goreleaser archive
+# names, so it can be substituted into the asset URL directly.
+ARG TARGETARCH
+
 WORKDIR /tmp
-RUN curl -fL --proto "=https" --tlsv1.2 -o soba.tar.gz "https://github.com/jonhadfield/soba/releases/download/${TAG}/soba_linux_amd64.tar.gz" \
+RUN curl -fL --proto "=https" --tlsv1.2 -o soba.tar.gz "https://github.com/jonhadfield/soba/releases/download/${TAG}/soba_linux_${TARGETARCH}.tar.gz" \
     && tar -xvzf soba.tar.gz \
     && rm ./*.gz \
     && mv ./soba /soba \


### PR DESCRIPTION
Publishes the image as a manifest list so one tag serves both amd64 and arm64.

## Why

goreleaser has always built `soba_linux_arm64.tar.gz` — it is attached to every release, `1.4.8` included. The Dockerfile just ignored it:

```dockerfile
RUN curl -fL ... "https://github.com/.../soba_linux_amd64.tar.gz"
```

So the published image is amd64 only. On arm64 hosts that means emulation where QEMU binfmt is configured, and `exec format error` where it is not — which rules out Graviton instances, most arm64 Kubernetes nodes, and small self-hosted boxes. All plausible homes for a backup tool.

## How

`TARGETARCH` is supplied by buildx once per platform, and its values (`amd64`, `arm64`) match Go's naming and therefore the goreleaser archive names, so it substitutes straight into the asset URL.

The scan had to be restructured, because **a multi-platform build cannot be loaded into the docker image store**. The flow is now:

1. build `linux/amd64` alone, `load: true` → a real local image
2. trivy report (HIGH+CRITICAL) and gate (CRITICAL, `exit-code: 1`)
3. build `linux/amd64,linux/arm64`, `push: true` → manifest list

The push build reuses the amd64 layers from step 1.

Selecting the `docker-container` driver also makes the existing `load: true` genuinely load-bearing rather than incidental — that driver does not write results to the local image store on its own. buildx says so itself during a build with no output specified:

```
WARNING: No output specified with docker-container driver.
Build result will only remain in the build cache.
```

## Verified locally against a real Docker daemon

Not reasoned about — actually run, using the same `docker-container` driver CI will use.

**Both platforms build, each fetching the correct asset:**

```
#11 [linux/arm64 4/4] RUN curl -fL ... soba_linux_arm64.tar.gz   → 2872k
#13 [linux/amd64 4/4] RUN curl -fL ... soba_linux_amd64.tar.gz   → 3157k
```

Different sizes, so genuinely different binaries.

**The arm64 image runs natively and reports the right version:**

```
$ docker image inspect soba-verify:arm64 --format '{{.Architecture}}/{{.Os}}'
arm64/linux

$ docker run --rm --platform linux/arm64 soba-verify:arm64 --version
soba: main.go:23: [1.4.8-5d25f13] 2026-07-28T20:37:47Z UTC
```

**Scanning one architecture is sufficient.** I scanned the arm64 image directly to check, and the profile is identical to amd64 — both resolve the same alpine branch tag and install the same apk packages:

| Image | CRITICAL | HIGH | Source |
|---|---|---|---|
| amd64 | 0 | 10 | stdlib |
| arm64 | 0 | 10 | stdlib |

Both gate runs exit 0, so this does not block the next release.

## Not verified

The push step and manifest-list creation, which need registry credentials and only run on a tag push. Everything up to and including the gate is verified above.

## Unrelated but worth knowing

The 10 HIGH findings are Go stdlib in the 1.4.8 binary, built with Go 1.25.10; they clear at >= 1.25.13. goreleaser uses whatever toolchain is local when you cut the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
