### PR TITLE
chore: pin the build toolchain to go1.26.7 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/jonhadfield/soba
 
 go 1.25.1
 
+toolchain go1.26.7
+
 require (
 	github.com/go-co-op/gocron/v2 v2.22.0
 	github.com/hashicorp/go-retryablehttp v0.7.8


### PR DESCRIPTION
Two lines in `go.mod`, but they move a decision that was living in a developer's shell into the repository.

```
go 1.25.1
toolchain go1.26.7
```

## Why

Which Go compiles a release was a property of whoever ran goreleaser. On this machine that shell exports

```
GOROOT = /Users/…/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.10.darwin-arm64
PATH   = …/toolchain@v0.0.1-go1.25.10.darwin-arm64/bin:…
```

so every build used **1.25.10** — even though 1.26.7 was installed via brew — and 1.4.8 shipped **10 fixable HIGH stdlib CVEs** (fixed in 1.25.13 and 1.26.4–1.26.6). Pointing `PATH` at the newer Go without also fixing `GOROOT` fails outright:

```
compile: version "go1.25.10" does not match go tool version "go1.26.7"
```

Telling people to `unset GOROOT` before releasing is not a fix; it is a step someone forgets exactly once.

## Verified

**In the unmodified environment, `GOROOT` still exported** — the case that matters, because it is what `make release` actually runs in:

```
GOROOT=…go1.25.10…    go version → go1.26.7
embedded version in the built binary → go1.26.7
HIGH/CRITICAL in that binary → 0        (was 10)
```

**Switching from an older Go on PATH** (simulating CI and goreleaser):

```
entry binary            → go1.25.10
version used to build   → go1.26.7
```

**Build, vet and tests** pass under 1.26.7, and `go mod tidy` leaves the file untouched beyond these two lines.

So the `unset GOROOT` workaround I suggested earlier is no longer needed once this merges.

## The `go` directive deliberately stays at 1.25.1

The two directives mean different things. `go` states the language version the project supports — unchanged here. `toolchain` states what to build with. Raising the former would drop support for anyone on 1.25.x for no benefit.

## One consequence worth knowing

golangci-lint reads the `toolchain` directive to determine its target version and refuses to run when it was itself built against something older:

```
can't load config: the Go language version (go1.25) used to build golangci-lint
is lower than the targeted Go version (1.26.7)
```

**CI is unaffected** — it pins v2.13.0, built with go1.27.0. Only local `make lint` is hit, on golangci-lint 2.12.2 (built with go1.25.11), and it needs a linter built with go1.26.7+.

Note this is not fixable via the Makefile's `GOTOOLCHAIN` pin: golangci-lint reads go.mod directly, so the pin has no effect on it. I tried and reverted that change; the Makefile is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
