### PR TITLE
chore: switch to the gomodguard_v2 linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters:
     - gocritic
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan


### PR DESCRIPTION
One line. `golangci-lint` v2.13.0 reports the old linter as deprecated:

```
The linter 'gomodguard' is deprecated (since v2.12.0) due to:
new major version. Replaced by gomodguard_v2.
```

```diff
-    - gomodguard
+    - gomodguard_v2
```

## Nothing to migrate

`gomodguard` appears once, in the `enable:` list, with no settings block — so there is no allow/block configuration to carry across.

## Verified, not assumed

The rename could plausibly have been accepted silently and left the linter switched off. It isn't:

```
$ golangci-lint linters
  [ENABLED]  gomodguard_v2:
  [DISABLED] gomodguard
```

And a full run is clean, with the warning gone:

```
$ make lint
0 issues.
```

Checked against golangci-lint **2.13.0**, the same version CI pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
