### PR TITLE
ci: anchor the changelog exclude patterns to commit prefixes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -109,10 +109,15 @@ snapshot:
 changelog:
   sort: asc
   filters:
+    # Anchored to conventional-commit prefixes. These were previously bare
+    # substrings matched anywhere in the message, so "test" also matched
+    # "testify", "tests" and "test-file", silently dropping real entries from
+    # every release: 1.5.0 lost the testify bump, the CI test-workflow PR and
+    # a Sonar fix.
     exclude:
-      - README
-      - test
-      - ignore
+      - '^test(\([^)]*\))?:'
+      - '^docs?(\([^)]*\))?:'
+      - '^ignore(\([^)]*\))?:'
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
The changelog `exclude` list held bare substrings. goreleaser matches these anywhere in the commit message, so `test` also matched `testify`, `tests` and `test-file`.

**1.5.0 silently lost three entries:**

```
Bump github.com/stretchr/testify from 1.11.1 to 1.12.1   (#208)   ← "testify"
ci: run tests in Actions, align Go versions, …           (#207)   ← "tests"
ci: fix sonar test-file exclusion to match subdirs       (#197)   ← "test-file"
```

The irony is that #207 — the PR that added test coverage to CI — is exactly what a reader would want listed, and it was invisible. This has been quietly eating entries from every release, not just this one.

`ignore` was the same hazard waiting to happen: it would drop any commit describing something the tool ignores, e.g. "fix: ignore empty repos".

## Verified against Go's own regexp on 400 commits of history

Not eyeballed — I replicated goreleaser's filter logic (`regexp.MatchString` per pattern) and ran both the old and new patterns over real commit messages.

**Old patterns, on the 1.5.0 range — exactly the three losses:**

```
DROP  Bump github.com/stretchr/testify from 1.11.1 to 1.12.1 (#208)
DROP  ci: run tests in Actions, align Go versions, … (#207)
DROP  ci: fix sonar test-file exclusion to match subdirectories (#197)
```

**New patterns, same range:** nothing dropped.

**New patterns across 400 commits — still excluding the real noise:**

```
DROP  test: deterministic GitHub backup tests; make live tests opt-in (#176)
DROP  test: fix infinite recursion in skipUnlessLiveGitHub (#179)
DROP  docs: add Sourcehut support
DROP  docs: describe git lfs backup env vars
      … 6 docs: commits total

KEEP  Bump github.com/stretchr/testify …
KEEP  ci: run tests in Actions …
KEEP  deps: bump githosts-utils to dd7970d (regression test) (#181)
KEEP  remove replaced library for testing.
```

`goreleaser check` validates the config.

## One deliberate behaviour change

`README` is replaced by `docs?:`, which is the convention this repo has used since 1.3.x — there are 8 `docs:` commits and zero `ignore:` commits in history.

Consequence: bare `update README.md` style commits will now appear in changelogs, where previously anything mentioning README was dropped. That seems the better failure mode — listing a real commit is cheaper than hiding one. Say if you would rather they stayed suppressed and I will add an anchored rule for them.

This affects future releases only. The 1.5.0 notes are being corrected separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
