### PR TITLE
test: make the live GitLab test opt-in, as the GitHub ones already are

### DIFF
--- a/internal/backup_test.go
+++ b/internal/backup_test.go
@@ -35,12 +35,20 @@ const (
 	sobaOrgOne                 = "soba-org-one"
 	sobaOrgTwo                 = "soba-org-two"
 	skipGitHubTestMissingToken = "Skipping GitHub test as %s is missing" //nolint:gosec
+	skipGitLabTestMissingToken = "Skipping GitLab test as %s is missing" //nolint:gosec
 	// envSobaLiveGitHubTests opts in to the live GitHub integration tests.
 	// They are skipped by default (including in CI) because GitHub secondary-
 	// rate-limits the shared token under the suite's back-to-back call volume;
 	// deterministic coverage lives in TestGithubRepositoryBackupWithMockAPI.
 	// See #176.
 	envSobaLiveGitHubTests = "SOBA_LIVE_GITHUB_TESTS"
+
+	// envSobaLiveGitLabTests opts in to the live GitLab integration tests.
+	// Like the GitHub ones they clone real repositories, so they fail on
+	// throttling or transient 403s from the host rather than on anything in
+	// this repository; CircleCI has a GitLab token configured and was failing
+	// intermittently as a result.
+	envSobaLiveGitLabTests = "SOBA_LIVE_GITLAB_TESTS"
 )
 
 // skipUnlessLiveGitHub skips a test unless live GitHub integration tests are
@@ -54,6 +62,20 @@ func skipUnlessLiveGitHub(t *testing.T) {
 
 	if os.Getenv(envGitHubToken) == "" {
 		t.Skipf(skipGitHubTestMissingToken, envGitHubToken)
+	}
+}
+
+// skipUnlessLiveGitLab skips a test unless live GitLab integration tests are
+// explicitly enabled and a token is present.
+func skipUnlessLiveGitLab(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv(envSobaLiveGitLabTests) == "" {
+		t.Skipf("skipping live GitLab test; set %s=true to run", envSobaLiveGitLabTests)
+	}
+
+	if os.Getenv(envGitLabToken) == "" {
+		t.Skipf(skipGitLabTestMissingToken, envGitLabToken)
 	}
 }
 
@@ -549,9 +571,7 @@ func TestPublicGithubRepositoryBackupWithExistingBackupsUsingRefs(t *testing.T) 
 }
 
 func TestPublicGitLabRepositoryBackup(t *testing.T) {
-	if os.Getenv(envGitLabToken) == "" {
-		t.Skipf("Skipping GitLab test as %s is missing", envGitLabToken)
-	}
+	skipUnlessLiveGitLab(t)
 
 	_ = os.Unsetenv(envSobaWebHookURL)
 


### PR DESCRIPTION
#176 made the live GitHub tests opt-in behind `SOBA_LIVE_GITHUB_TESTS` so CI would stop depending on a rate-limited token. The GitLab equivalent never got the same treatment — it still runs whenever a token happens to be present:

```go
// GitHub — explicit opt-in
func skipUnlessLiveGitHub(t *testing.T)

// GitLab — runs if a token is lying around
if os.Getenv(envGitLabToken) == "" { t.Skipf(...) }
```

## What that cost

CircleCI has a GitLab token configured, so it clones real repositories on every build. Build **707** failed on an HTTP 403 from the clone while every neighbouring build passed:

```
709  success  main
708  success  ci/fix-changelog-filters
707  failed   dependabot/…claude-code-action-1.0.195   ← live GitLab clone, HTTP 403
706  success  main
```

The failing PR only bumped a pinned action SHA in two workflow files. Nothing it changed could affect a GitLab clone.

There is a second, quieter problem: GitHub Actions has **no** GitLab token, so it skipped that test entirely. The two CI systems were covering different things and neither reported the difference.

## The change

Mirrors the GitHub pattern exactly — `SOBA_LIVE_GITLAB_TESTS` plus a `skipUnlessLiveGitLab` helper, alongside the existing `skipGitHubTestMissingToken` constant.

## Verified with a token present

This matters, because "the test skips now" is easy to achieve by accident. My shell has `GITLAB_TOKEN` set, which is precisely the condition that used to break the run:

**Default — skips, and the suite passes:**

```
$ go test -p 1 -parallel 1 -failfast ./...
ok  github.com/jonhadfield/soba/internal  6.717s

backup_test.go:574: skipping live GitLab test; set SOBA_LIVE_GITLAB_TESTS=true to run
--- SKIP: TestPublicGitLabRepositoryBackup (0.00s)
```

**Opt-in — still genuinely runs:**

```
$ SOBA_LIVE_GITLAB_TESTS=true go test -run TestPublicGitLabRepositoryBackup -v ./internal/
=== RUN   TestPublicGitLabRepositoryBackup
soba: gitlab.go:12: backing up GitLab repos
FAIL
```

It reaches the clone and fails on my expired local token — the same class of failure that broke CircleCI. That confirms this gates the test rather than disabling it.

`make lint` reports 0 issues and `gofmt` is clean.

## Note

This does not fix the underlying credential. Whatever GitLab token CircleCI holds appears to be returning 403; it is simply no longer able to fail unrelated builds. Running the live suite deliberately will need that token refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
