### PR TITLE
docs: correct the supported platform claims and surface arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <img src="docs/soba.png" alt="logo" width="200"/>
 
 [![GitHub Release][release-img]][release]
+[![Test](https://github.com/jonhadfield/soba/actions/workflows/test.yml/badge.svg)](https://github.com/jonhadfield/soba/actions/workflows/test.yml)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/1bd46b99467c45d99e4903b44a16f874)](https://app.codacy.com/gh/jonhadfield/soba/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![CodeQL](https://github.com/jonhadfield/soba/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/jonhadfield/soba/actions/workflows/codeql-analysis.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jonhadfield/soba)](https://goreportcard.com/report/github.com/jonhadfield/soba)
@@ -22,7 +23,7 @@ soba backs up your Git repositories from GitHub, GitLab, Bitbucket, Azure DevOps
 | **Smart rotation** | Keep only the _n_ most recent backups per repo |
 | **Git LFS** | Back up large file storage objects alongside repo bundles |
 | **Notifications** | Slack, Telegram, webhooks, and [ntfy](https://ntfy.sh/) alerts |
-| **Runs anywhere** | Binary, Docker, Kubernetes, or Synology NAS |
+| **Runs anywhere** | Binary, Docker, Kubernetes, or Synology NAS &mdash; amd64 and arm64 |
 
 ## Quick Start
 
@@ -211,8 +212,22 @@ If the bundle is encrypted, [decrypt it first](#decrypting-backups).
 
 ## Supported Platforms
 
-Tested on Windows 10, macOS, and Linux (amd64).
-Should also work on Linux (386, arm, arm64), FreeBSD, NetBSD, and OpenBSD.
+Binaries are published for every combination below on each [release](https://github.com/jonhadfield/soba/releases):
+
+| OS | amd64 | arm64 |
+|:--------|:-----:|:-----:|
+| Linux   |   ✅   |   ✅   |
+| macOS   |   ✅   |   ✅   |
+| Windows |   ✅   |   ✅   |
+| FreeBSD |   ✅   |   ✅   |
+
+The Docker image is multi-architecture, so `ghcr.io/jonhadfield/soba` resolves to the right build automatically and runs natively on Apple Silicon, AWS Graviton, and Raspberry Pi:
+
+```bash
+docker buildx imagetools inspect ghcr.io/jonhadfield/soba:latest
+```
+
+soba is pure Go with cgo disabled, so it should also build from source for any other target Go supports.
 
 ## Changelog
 


### PR DESCRIPTION
## The platform section advertised binaries that have never existed

```
Tested on Windows 10, macOS, and Linux (amd64).
Should also work on Linux (386, arm, arm64), FreeBSD, NetBSD, and OpenBSD.
```

`.goreleaser.yml` builds `amd64` and `arm64` only. The `goarm: "7"` entry is inert, because `arm` is not in `goarch`. Confirmed against what 1.5.0 actually shipped:

```
soba_darwin_amd64   soba_darwin_arm64
soba_linux_amd64    soba_linux_arm64
soba_windows_amd64  soba_windows_arm64
soba_freebsd_amd64  soba_freebsd_arm64
```

So **386, 32-bit arm, NetBSD and OpenBSD** were all advertised and none are built — someone on OpenBSD was being sent to look for a binary that does not exist.

The reverse problem too: **arm64 was undersold** as something that "should also work", when it is a first-class target on all four operating systems.

## And nothing mentioned the multi-arch image

1.5.0 made the Docker image a manifest list, which is exactly the detail a Raspberry Pi or Graviton user needs — and the README gave them no way to know. Now covered, with the command to verify it.

## Changes

- Platform prose replaced with a table of what actually ships
- A note that the image resolves per architecture, with `docker buildx imagetools inspect`
- `amd64 and arm64` added to the **Runs anywhere** feature row, so it is visible without scrolling to the bottom
- A **Test** badge — the suite has run in Actions since 1.5.0, but the badge row showed only release, Codacy, CodeQL and Go Report Card, so the one people look for first was absent (badge URL returns HTTP 200)

## Checked and found fine

The repo description and all 18 topics are accurate and match the code, so no change there. All four local links (`docs/soba.png`, `docs/providers.md`, `docs/CHANGELOG.md`, `kubernetes/README.md`) resolve.

One thing not addressed here: `docs/CHANGELOG.md` is five releases behind, stopping at 1.4.4 while 1.5.0 is out. That is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
