### PR TITLE
docs: backfill the changelog for 1.4.5 through 1.5.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,36 @@
+### 1.5.0 release 2026-08-20
+
+- Publish the Docker image for arm64 as well as amd64, so a single tag serves both architectures and runs natively on Apple Silicon, AWS Graviton and Raspberry Pi
+- Build releases with Go 1.26.7, clearing ten fixable vulnerabilities in the Go standard library
+- Base the Docker image on the Alpine 3.22 branch rather than a frozen point release, clearing nineteen inherited CVEs
+- Fail the release if the built image carries a critical vulnerability, rather than reporting after publishing
+- Bump slack-go to 0.29.0 and testify to 1.12.1
+- Run the test suite in GitHub Actions alongside CircleCI
+
+### 1.4.8 release 2026-07-28
+
+- Harden the backup runner, environment file reads, and notification clients
+- Retry on GitHub primary rate limits via githosts-utils v2.1.2
+- Migrate to the githosts-utils /v2 module path
+- Make the live GitHub integration tests opt-in so CI no longer depends on a rate-limited token
+- Bump dependencies
+
+### 1.4.7 release 2026-04-19
+
+- Use the replacement Bitbucket API via githosts-utils
+- Document the Bitbucket scopes required for workspaces
+- Pin GitHub Actions to specific commit SHAs
+
+### 1.4.6 release 2026-04-17
+
+- Add support for Bitbucket workspaces
+- Bump dependencies
+
+### 1.4.5 release 2026-03-23
+
+- Improve error logging from githosts-utils
+- Bump dependencies
+
 ### 1.4.4 release 2026-03-15
 
 - Fix gosec linting issues


### PR DESCRIPTION
`docs/CHANGELOG.md` stopped at **1.4.4 (2026-03-15)** while **1.5.0** was out — five releases missing.

The README sends readers there for release history, so anyone asking "what changed?" saw nothing since March, including the release that added arm64 images.

```
before          after
1.4.4    <-     1.5.0
1.4.3           1.4.8
1.4.2           1.4.7
1.3.9           1.4.6
                1.4.5
                1.4.4
                ...
```

## How the entries were written

From the commits in each tag range (`git log <prev>..<tag>`), condensed into user-facing bullets to match the existing style rather than pasted in as a raw commit list. Dates are the actual tag dates.

The 1.5.0 entry leads with what users can act on — the multi-arch image, the Go 1.26.7 rebuild clearing ten stdlib CVEs, and the Alpine base moving off a frozen point release — rather than the CI work that made up most of the commits.

## Not addressed

**1.4.0 and 1.4.1 are also missing**, which I noticed while checking the ordering. That gap predates the ones this fixes, and filling it means reconstructing releases from nearly a year ago, so I left it alone rather than widening the scope. The jump from 1.4.2 straight to 1.3.9 in the file is that gap, not a mistake introduced here.

Happy to fill it in as a follow-up if you want the history complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
