### PR TITLE
ci: scan both architectures, align CircleCI Go, and harden the tag step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,10 @@ version: 2
 jobs:
   build:
     docker:
-      # Must track the go directive in go.mod (1.25.1). On an older image Go
-      # silently downloads a matching toolchain on every build, and would fail
-      # outright under GOTOOLCHAIN=local.
-      - image: cimg/go:1.25.1
+      # Must track the toolchain directive in go.mod (go1.26.7), not the go
+      # directive. On an older image Go silently downloads a matching toolchain
+      # on every build, and would fail outright under GOTOOLCHAIN=local.
+      - image: cimg/go:1.26.7
     steps:
       - checkout
       - run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,16 +49,24 @@ jobs:
     # name. It replaces git describe --tags, which depended on the tag object
     # being present in a fetch-depth 1 checkout and would emit a
     # <tag>-<n>-g<sha> string if HEAD were ever not exactly on a tag.
+    # Passed via env rather than interpolated into the run script: git permits
+    # backticks, $, ; and | in tag names, which would otherwise execute in a job
+    # holding the registry credentials.
     -
       name: Set release tag
-      run: echo "TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+      env:
+        TAG_NAME: ${{ github.ref_name }}
+      run: echo "TAG=$TAG_NAME" >> "$GITHUB_ENV"
 
-    # Built for a single platform and loaded locally so the scan below has a
-    # real image to inspect: a multi-platform result cannot be loaded into the
-    # docker image store. The layers are reused by the push build, which is a
-    # cache hit for amd64.
+    # Each architecture is built and loaded separately, because a
+    # multi-platform result cannot be loaded into the docker image store and so
+    # cannot be scanned. Both are scanned below: Alpine's arm64 package set can
+    # carry a CRITICAL that amd64 does not, or receive the fix later, so
+    # scanning only amd64 would publish an unscanned arm64 layer under the same
+    # tag. These tags are local to the runner and never pushed; the push build
+    # reuses their layers.
     -
-      name: build image for scanning
+      name: build amd64 image for scanning
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
       with:
         context: ./docker
@@ -67,25 +75,56 @@ jobs:
         platforms: linux/amd64
         push: false
         load: true
-        tags: ${{ github.repository }}:${{ env.TAG }}
+        tags: soba-scan:amd64
 
-    # Reported for visibility, does not block. The release binary currently
-    # carries Go stdlib HIGHs that clear only when goreleaser builds against a
-    # newer toolchain.
-    - name: trivy image scan (report HIGH and CRITICAL)
+    -
+      name: build arm64 image for scanning
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+      with:
+        context: ./docker
+        file: ./docker/Dockerfile
+        build-args: TAG=${{ env.TAG }}
+        platforms: linux/arm64
+        push: false
+        load: true
+        tags: soba-scan:arm64
+
+    # Reported for visibility, does not block. The release binary carries Go
+    # stdlib HIGHs whenever goreleaser builds against a toolchain older than the
+    # one the advisories require.
+    - name: trivy scan amd64 (report HIGH and CRITICAL)
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
-        image-ref: ${{ github.repository }}:${{ env.TAG }}
+        image-ref: soba-scan:amd64
         exit-code: 0
         severity: HIGH,CRITICAL
         ignore-unfixed: true
 
-    # The gate: fails the job before the push step, so a CRITICAL finding stops
-    # the release rather than being published and reported afterwards.
-    - name: trivy image scan (fail on CRITICAL)
+    - name: trivy scan arm64 (report HIGH and CRITICAL)
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
-        image-ref: ${{ github.repository }}:${{ env.TAG }}
+        image-ref: soba-scan:arm64
+        exit-code: 0
+        severity: HIGH,CRITICAL
+        ignore-unfixed: true
+
+    # The gates: these fail the job before the push step, so a CRITICAL finding
+    # on either architecture stops the release rather than being published and
+    # reported afterwards. ignore-unfixed is deliberate: a CRITICAL with no
+    # patched Alpine package available would otherwise block every release until
+    # upstream ships a fix.
+    - name: trivy scan amd64 (fail on CRITICAL)
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        image-ref: soba-scan:amd64
+        exit-code: 1
+        severity: CRITICAL
+        ignore-unfixed: true
+
+    - name: trivy scan arm64 (fail on CRITICAL)
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        image-ref: soba-scan:arm64
         exit-code: 1
         severity: CRITICAL
         ignore-unfixed: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Publish the Docker image for arm64 as well as amd64, so a single tag serves both architectures and runs natively on Apple Silicon, AWS Graviton and Raspberry Pi
 - Build releases with Go 1.26.7, clearing ten fixable vulnerabilities in the Go standard library
 - Base the Docker image on the Alpine 3.22 branch rather than a frozen point release, clearing nineteen inherited CVEs
-- Fail the release if the built image carries a critical vulnerability, rather than reporting after publishing
+- Fail the release if the built image carries a critical vulnerability with a fix available, rather than reporting after publishing
 - Bump slack-go to 0.29.0 and testify to 1.12.1
 - Run the test suite in GitHub Actions alongside CircleCI
 


### PR DESCRIPTION
Four findings from a code review of this session's changes. Three are regressions introduced during it.

## 1. The gate scanned amd64, the push published both

`build image for scanning` used `platforms: linux/amd64`; `push image` used `linux/amd64,linux/arm64`. The arm64 layer went out under the same tag having never been scanned.

I had previously justified this by scanning an arm64 build directly and finding an identical profile — but that was a **point-in-time sample, not a guarantee**. Alpine's arm64 package set can pick up a CRITICAL that amd64 does not, or receive the fix later, and nothing in the pipeline would notice.

Each architecture is now built and loaded separately (a multi-platform result cannot be loaded into the docker image store, so it cannot be scanned), reported on, and gated.

## 2. CircleCI was the only builder on a different Go

```
comment: "Must track the go directive in go.mod (1.25.1)"
image:   cimg/go:1.25.1
go.mod:  toolchain go1.26.7
```

The comment stopped being true when the `toolchain` directive landed. Every build downloaded go1.26.7 before compiling — the exact cost the pin was meant to avoid — while `test.yml` and `golangci-lint.yml` install 1.26.7 directly via `go-version-file`. Now tracks the toolchain directive.

## 3. Tag names reached the shell

```yaml
run: echo "TAG=${{ github.ref_name }}" >> $GITHUB_ENV
```

Git permits backticks, `$`, `;` and `|` in tag names, so a crafted tag would execute in a job holding `DOCKERHUB_TOKEN` and a `packages: write` token. Requires push access, so low practical risk, but free to close: the value now arrives via `env:`.

## 4. The changelog overstated the gate

1.5.0 said "Fail the release if the built image carries a critical vulnerability" while the step sets `ignore-unfixed: true`. Now says "with a fix available", and the workflow records why that leniency is deliberate — without it, a CRITICAL with no patched Alpine package would block every release until upstream shipped a fix.

## Verified

Built and loaded both architectures with the same `docker-container` driver CI uses, then ran both gates:

```
gate amd64 -> exit 0        report amd64 -> 0 HIGH/CRITICAL
gate arm64 -> exit 0        report arm64 -> 0 HIGH/CRITICAL
```

Worth noting the HIGH count is now **0, down from 10** — the Go 1.26.7 toolchain pin carried through into the released binary.

## Cost

The arm64 scan build runs under QEMU on an amd64 runner, adding a few minutes per release. That is the price of not publishing an unscanned layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
