### PR TITLE
build(deps): bump githosts-utils to v2.1.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.7
 require (
 	github.com/go-co-op/gocron/v2 v2.22.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/jonhadfield/githosts-utils/v2 v2.1.2
+	github.com/jonhadfield/githosts-utils/v2 v2.1.4
 	github.com/slack-go/slack v0.29.0
 	github.com/stretchr/testify v1.12.1
 	gitlab.com/tozd/go/errors v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
-github.com/jonhadfield/githosts-utils/v2 v2.1.2 h1:88DN2+IsqQDO1yZ/Rc+JH1y1VrgeUdcY5Jb/+kZyH4U=
-github.com/jonhadfield/githosts-utils/v2 v2.1.2/go.mod h1:EBBhZdf+UWCPWB68OxC1THvLFinMWRkD/lbdl9aVA6U=
+github.com/jonhadfield/githosts-utils/v2 v2.1.4 h1:3SBOihfmPp6KAOBlVB/bGAqiPF43JHr0Bu3eiPLJbWA=
+github.com/jonhadfield/githosts-utils/v2 v2.1.4/go.mod h1:EBBhZdf+UWCPWB68OxC1THvLFinMWRkD/lbdl9aVA6U=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Picks up a fix to wildcard organization discovery: organizations were looked up by display name rather than login, so any organization whose display name differed from its login was queried under a value GitHub cannot resolve, aborting the entire discovery run. Only the `GITHUB_ORGS="*"` path was affected — explicitly listed organizations are already logins.

Also makes two new opt-in environment variables available:

| Variable | Effect |
| --- | --- |
| `GITHUB_LOG_API_USAGE` | log GraphQL rate-limit headers and a per-run summary of requests and repositories per discovery pass |
| `GITHUB_MAX_CONCURRENT` | override the number of concurrent backup workers — the main lever on peak memory |

No default behaviour changes. `go build`, `go vet` and `go test ./...` all pass locally.